### PR TITLE
Adds support for python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: rwx-ubuntu-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - py: "37"
+            python-version: "3.7"
           - py: "38"
             python-version: "3.8"
           - py: "39"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ abq test -- pytest
 
 `pytest-abq` is actively tested against
 
-- Python 3.8, 3.9, 3.10
+- Python 3.7, 3.8, 3.9, 3.10
 - Pytest 7.0, 7.2
 
 `pytest-abq` may support Python and pytest versions beyond these.

--- a/integration_tests/multifile/out/py310/pytest7.0.*/results.json
+++ b/integration_tests/multifile/out/py310/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py310/pytest7.2.*/results.json
+++ b/integration_tests/multifile/out/py310/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py37/pytest7.0.*/manifest.json
+++ b/integration_tests/multifile/out/py37/pytest7.0.*/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest": {
+    "members": [
+      {
+        "type": "test",
+        "id": "test_file1.py::test_1",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file1.py::test_2",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file2.py::test_3",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file2.py::test_4",
+        "tags": [],
+        "meta": {}
+      }
+    ],
+    "init_meta": {}
+  },
+  "native_runner_protocol": {
+    "type": "abq_protocol_version",
+    "major": 0,
+    "minor": 2
+  },
+  "native_runner_specification": {
+    "type": "abq_native_runner_specification",
+    "name": "pytest_abq",
+    "version": "7.2.2",
+    "test_framework": "pytest",
+    "test_framework_version": "7.0.1",
+    "language": "Python",
+    "language_version": "3.7",
+    "host": "cpython-37"
+  }
+}

--- a/integration_tests/multifile/out/py37/pytest7.0.*/results.json
+++ b/integration_tests/multifile/out/py37/pytest7.0.*/results.json
@@ -1,0 +1,126 @@
+[
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_file1.py::test_1",
+        "display_name": "test_file1.py::test_1",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file1.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881889242
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_file1.py::test_2",
+        "display_name": "test_file1.py::test_2",
+        "output": "def test_2():\n>       assert 1 == 2\nE       assert 1 == 2\n\ntest_file1.py:7: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file1.py",
+          "line": 5,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881889266
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_file2.py::test_3",
+        "display_name": "test_file2.py::test_3",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file2.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881889267
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_file2.py::test_4",
+        "display_name": "test_file2.py::test_4",
+        "output": "def test_4():\n>       assert 1 == 2\nE       assert 1 == 2\n\ntest_file2.py:7: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file2.py",
+          "line": 5,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881889268
+      }
+    }
+  ]
+]

--- a/integration_tests/multifile/out/py37/pytest7.0.*/results.json
+++ b/integration_tests/multifile/out/py37/pytest7.0.*/results.json
@@ -25,7 +25,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881889242
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -57,7 +57,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881889266
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -87,7 +87,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881889267
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -119,7 +119,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881889268
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py37/pytest7.2.*/manifest.json
+++ b/integration_tests/multifile/out/py37/pytest7.2.*/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest": {
+    "members": [
+      {
+        "type": "test",
+        "id": "test_file1.py::test_1",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file1.py::test_2",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file2.py::test_3",
+        "tags": [],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_file2.py::test_4",
+        "tags": [],
+        "meta": {}
+      }
+    ],
+    "init_meta": {}
+  },
+  "native_runner_protocol": {
+    "type": "abq_protocol_version",
+    "major": 0,
+    "minor": 2
+  },
+  "native_runner_specification": {
+    "type": "abq_native_runner_specification",
+    "name": "pytest_abq",
+    "version": "7.2.2",
+    "test_framework": "pytest",
+    "test_framework_version": "7.2.2",
+    "language": "Python",
+    "language_version": "3.7",
+    "host": "cpython-37"
+  }
+}

--- a/integration_tests/multifile/out/py37/pytest7.2.*/results.json
+++ b/integration_tests/multifile/out/py37/pytest7.2.*/results.json
@@ -1,0 +1,126 @@
+[
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_file1.py::test_1",
+        "display_name": "test_file1.py::test_1",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file1.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881899016
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_file1.py::test_2",
+        "display_name": "test_file1.py::test_2",
+        "output": "def test_2():\n>       assert 1 == 2\nE       assert 1 == 2\n\ntest_file1.py:7: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file1.py",
+          "line": 5,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881899041
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_file2.py::test_3",
+        "display_name": "test_file2.py::test_3",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file2.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881899042
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_file2.py::test_4",
+        "display_name": "test_file2.py::test_4",
+        "output": "def test_4():\n>       assert 1 == 2\nE       assert 1 == 2\n\ntest_file2.py:7: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_file2.py",
+          "line": 5,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881899044
+      }
+    }
+  ]
+]

--- a/integration_tests/multifile/out/py37/pytest7.2.*/results.json
+++ b/integration_tests/multifile/out/py37/pytest7.2.*/results.json
@@ -25,7 +25,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881899016
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -57,7 +57,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881899041
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -87,7 +87,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881899042
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -119,7 +119,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881899044
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py38/pytest7.0.*/results.json
+++ b/integration_tests/multifile/out/py38/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py38/pytest7.2.*/results.json
+++ b/integration_tests/multifile/out/py38/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py39/pytest7.0.*/results.json
+++ b/integration_tests/multifile/out/py39/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/multifile/out/py39/pytest7.2.*/results.json
+++ b/integration_tests/multifile/out/py39/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +56,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -115,7 +118,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py310/pytest7.0.*/results.json
+++ b/integration_tests/parameterized/out/py310/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py310/pytest7.2.*/results.json
+++ b/integration_tests/parameterized/out/py310/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py37/pytest7.0.*/manifest.json
+++ b/integration_tests/parameterized/out/py37/pytest7.0.*/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest": {
+    "members": [
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[3+5-8]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[2+4-6]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[6*9-42]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      }
+    ],
+    "init_meta": {}
+  },
+  "native_runner_protocol": {
+    "type": "abq_protocol_version",
+    "major": 0,
+    "minor": 2
+  },
+  "native_runner_specification": {
+    "type": "abq_native_runner_specification",
+    "name": "pytest_abq",
+    "version": "7.2.2",
+    "test_framework": "pytest",
+    "test_framework_version": "7.0.1",
+    "language": "Python",
+    "language_version": "3.7",
+    "host": "cpython-37"
+  }
+}

--- a/integration_tests/parameterized/out/py37/pytest7.0.*/results.json
+++ b/integration_tests/parameterized/out/py37/pytest7.0.*/results.json
@@ -1,0 +1,94 @@
+[
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_parameterized.py::test_eval[3+5-8]",
+        "display_name": "test_parameterized.py::test_eval[3+5-8]",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881908960
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_parameterized.py::test_eval[2+4-6]",
+        "display_name": "test_parameterized.py::test_eval[2+4-6]",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881908961
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_parameterized.py::test_eval[6*9-42]",
+        "display_name": "test_parameterized.py::test_eval[6*9-42]",
+        "output": "test_input = '6*9', expected = 42\n\n    @pytest.mark.parametrize(\"test_input,expected\", [(\"3+5\", 8), (\"2+4\", 6), (\"6*9\", 42)])\n    def test_eval(test_input, expected):\n>       assert eval(test_input) == expected\nE       AssertionError: assert 54 == 42\nE        +  where 54 = eval('6*9')\n\ntest_parameterized.py:5: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881908985
+      }
+    }
+  ]
+]

--- a/integration_tests/parameterized/out/py37/pytest7.0.*/results.json
+++ b/integration_tests/parameterized/out/py37/pytest7.0.*/results.json
@@ -25,7 +25,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881908960
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +55,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881908961
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -87,7 +87,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881908985
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py37/pytest7.2.*/manifest.json
+++ b/integration_tests/parameterized/out/py37/pytest7.2.*/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest": {
+    "members": [
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[3+5-8]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[2+4-6]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      },
+      {
+        "type": "test",
+        "id": "test_parameterized.py::test_eval[6*9-42]",
+        "tags": [
+          "parametrize"
+        ],
+        "meta": {}
+      }
+    ],
+    "init_meta": {}
+  },
+  "native_runner_protocol": {
+    "type": "abq_protocol_version",
+    "major": 0,
+    "minor": 2
+  },
+  "native_runner_specification": {
+    "type": "abq_native_runner_specification",
+    "name": "pytest_abq",
+    "version": "7.2.2",
+    "test_framework": "pytest",
+    "test_framework_version": "7.2.2",
+    "language": "Python",
+    "language_version": "3.7",
+    "host": "cpython-37"
+  }
+}

--- a/integration_tests/parameterized/out/py37/pytest7.2.*/results.json
+++ b/integration_tests/parameterized/out/py37/pytest7.2.*/results.json
@@ -1,0 +1,94 @@
+[
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_parameterized.py::test_eval[3+5-8]",
+        "display_name": "test_parameterized.py::test_eval[3+5-8]",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881918687
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "test_parameterized.py::test_eval[2+4-6]",
+        "display_name": "test_parameterized.py::test_eval[2+4-6]",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881918687
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": {
+          "Failure": {}
+        },
+        "id": "test_parameterized.py::test_eval[6*9-42]",
+        "display_name": "test_parameterized.py::test_eval[6*9-42]",
+        "output": "test_input = '6*9', expected = 42\n\n    @pytest.mark.parametrize(\"test_input,expected\", [(\"3+5\", 8), (\"2+4\", 6), (\"6*9\", 42)])\n    def test_eval(test_input, expected):\n>       assert eval(test_input) == expected\nE       AssertionError: assert 54 == 42\nE        +  where 54 = eval('6*9')\n\ntest_parameterized.py:5: AssertionError",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "location": {
+          "file": "test_parameterized.py",
+          "line": 2,
+          "column": null
+        },
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED",
+        "timestamp": 1680881918714
+      }
+    }
+  ]
+]

--- a/integration_tests/parameterized/out/py37/pytest7.2.*/results.json
+++ b/integration_tests/parameterized/out/py37/pytest7.2.*/results.json
@@ -25,7 +25,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881918687
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -55,7 +55,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881918687
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -87,7 +87,7 @@
         },
         "stderr": "STRIPPED",
         "stdout": "STRIPPED",
-        "timestamp": 1680881918714
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py38/pytest7.0.*/results.json
+++ b/integration_tests/parameterized/out/py38/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py38/pytest7.2.*/results.json
+++ b/integration_tests/parameterized/out/py38/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py39/pytest7.0.*/results.json
+++ b/integration_tests/parameterized/out/py39/pytest7.0.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/parameterized/out/py39/pytest7.2.*/results.json
+++ b/integration_tests/parameterized/out/py39/pytest7.2.*/results.json
@@ -24,7 +24,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -53,7 +54,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ],
@@ -84,7 +86,8 @@
           "column": null
         },
         "stderr": "STRIPPED",
-        "stdout": "STRIPPED"
+        "stdout": "STRIPPED",
+        "timestamp": "STRIPPED"
       }
     }
   ]

--- a/integration_tests/sanitize.py
+++ b/integration_tests/sanitize.py
@@ -8,6 +8,7 @@ def sanitize_results(results):
             result["result"]["runtime"]["Nanoseconds"] = "STRIPPED"
             result["result"]["stderr"] = "STRIPPED"
             result["result"]["stdout"] = "STRIPPED"
+            result["result"]["timestamp"] = "STRIPPED"
     return results
 
 def sanitize_manifest(results):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-abq"
-version = "1.0.0"
+version = "1.0.1"
 description = "Pytest integration for the ABQ universal test runner."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/pytest_abq/abq/config.py
+++ b/src/pytest_abq/abq/config.py
@@ -4,7 +4,12 @@ import socket
 import sys
 import platform
 import pytest
-from typing import Literal, Union
+from typing import Union
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 from .types import (
     AbqNativeRunnerSpawnedMessage,

--- a/src/pytest_abq/abq/types.py
+++ b/src/pytest_abq/abq/types.py
@@ -1,7 +1,12 @@
 import socket
-from typing import Any, Dict, List, Optional, Union, Literal, TypedDict
+from typing import Any, Dict, List, Optional, Union
 from typing_extensions import NotRequired
 
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal, TypedDict
 
 Connection = socket.socket
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    py{38,39,310}-{multifile,parameterized}-pytest{70,72}
+    py{37,38,39,310}-{multifile,parameterized}-pytest{70,72}
 isolated_build = true
 
 [testenv]
 setenv =
+    py37: PY_VERSION = 37
     py38: PY_VERSION = 38
     py39: PY_VERSION = 39
     py310: PY_VERSION = 310


### PR DESCRIPTION
Despite Python 3.7 nearing EOL, there are still many projects using it. This patch adds pytest-abq support for py37.